### PR TITLE
Improve speed of `msgify(point_cloud_2_np)` by 115x

### DIFF
--- a/ros2_numpy/point_cloud2.py
+++ b/ros2_numpy/point_cloud2.py
@@ -172,9 +172,14 @@ def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None):
     # over each byte in python.
     # Here we create an array.array object using a memoryview, limiting copying and
     # increasing performance.
-    memory_view = memoryview(cloud_arr).cast("B")
+    memory_view = memoryview(cloud_arr)
+    if memory_view.nbytes > 0:
+        array_bytes = memory_view.cast("B")
+    else:
+        # Casting raises a TypeError if the array has no elements
+        array_bytes = b""
     as_array = array.array("B")
-    as_array.frombytes(memory_view)
+    as_array.frombytes(array_bytes)
     cloud_msg.data = as_array
     return cloud_msg
 

--- a/ros2_numpy/point_cloud2.py
+++ b/ros2_numpy/point_cloud2.py
@@ -39,6 +39,7 @@ __docformat__ = "restructuredtext en"
 
 from .registry import converts_from_numpy, converts_to_numpy
 
+import array
 import numpy as np
 from sensor_msgs.msg import PointCloud2, PointField
 
@@ -165,7 +166,16 @@ def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None):
     cloud_msg.is_dense = \
       all([np.isfinite(
             cloud_arr[fname]).all() for fname in cloud_arr.dtype.names])
-    cloud_msg.data = cloud_arr.tostring()
+
+    # The PointCloud2.data setter will create an array.array object for you if you don't
+    # provide it one directly. This causes very slow performance because it iterates
+    # over each byte in python.
+    # Here we create an array.array object using a memoryview, limiting copying and
+    # increasing performance.
+    memory_view = memoryview(cloud_arr).cast("B")
+    as_array = array.array("B")
+    as_array.frombytes(memory_view)
+    cloud_msg.data = as_array
     return cloud_msg
 
 def merge_rgb_fields(cloud_arr):

--- a/test/test_pointclouds.py
+++ b/test/test_pointclouds.py
@@ -75,8 +75,15 @@ class TestPointClouds(unittest.TestCase):
         np.testing.assert_equal(points_arr, new_points_arr)
 
     def test_roundtrip_numpy(self):
-
         points_arr = self.makeArray(100)
+        cloud_msg = rnp.msgify(PointCloud2, points_arr)
+        new_points_arr = rnp.numpify(cloud_msg)
+
+        np.testing.assert_equal(points_arr, new_points_arr)
+
+    def test_roundtrip_zero_points(self):
+        """Test to make sure zero point arrays don't raise memoryview.cast(*) errors"""
+        points_arr = self.makeArray(0)
         cloud_msg = rnp.msgify(PointCloud2, points_arr)
         new_points_arr = rnp.numpify(cloud_msg)
 


### PR DESCRIPTION
I noticed that on large point clouds, converting from numpy to PointCloud2 was extremely time consuming. It took 2.4 seconds to convert a point cloud representing (x. y, z, rgb) for a structured array of shape (1944, 1200). This cloud is about 40 megabytes when serialized.

## Background
As I looked into it, I found that the speed problem was not actually in `cloud_arr.tostring()`, but rather inside of the PointCloud2.data property, when it calls `self._data = array.array('B', value)`.

Reference code:
```
class PointCloud2:
	...

	@data.setter
    def data(self, value):
        if isinstance(value, array.array):
            assert value.typecode == 'B', \
                "The 'data' array.array() must have the type code of 'B'"
            self._data = value
            return
        self._data = array.array('B', value)
```

From looking into it, it appears that the entire byte array is iterated upon painstakingly and copied by `array.array('B', value)`, 

To resolve this, I used a `memoryview` and `array.array.frombytes()` to reduce the copying and iteration. In fact, the only copy is [here](https://github.com/python/cpython/blob/088dd76dba68c2538776d9920607f81e54544cbd/Modules/arraymodule.c#L1682), which uses `memcpy` and is quite efficient- as opposed to currently where it iterates over each byte as the array.array object is built.

## Benchmarks
**Current Implementation**:
`msgify(large_point_cloud)`: 2.46 seconds

**This  PR**:
`msgify(large_point_cloud)`: 0.0211 seconds