### PR TITLE
Remove unneeded array and handle bigendian

### DIFF
--- a/ros2_numpy/point_cloud2.py
+++ b/ros2_numpy/point_cloud2.py
@@ -37,6 +37,8 @@ Functions for working with PointCloud2.
 
 __docformat__ = "restructuredtext en"
 
+import sys
+
 from .registry import converts_from_numpy, converts_to_numpy
 
 import numpy as np
@@ -58,15 +60,6 @@ type_mappings = [(PointField.INT8, np.dtype('int8')),
 pftype_to_nptype = dict(type_mappings)
 nptype_to_pftype = dict((nptype, pftype) for pftype, nptype in type_mappings)
 
-# sizes (in bytes) of PointField types
-pftype_sizes = {PointField.INT8: 1,
-                PointField.UINT8: 1,
-                PointField.INT16: 2,
-                PointField.UINT16: 2,
-                PointField.INT32: 4,
-                PointField.UINT32: 4,
-                PointField.FLOAT32: 4,
-                PointField.FLOAT64: 8}
 
 @converts_to_numpy(PointField, plural=True)
 def fields_to_dtype(fields, point_step):
@@ -86,7 +79,7 @@ def fields_to_dtype(fields, point_step):
             dtype = np.dtype((dtype, f.count))
 
         np_dtype_list.append((f.name, dtype))
-        offset += pftype_sizes[f.datatype] * f.count
+        offset += type_mappings[f.datatype].itemsize * f.count
 
     # might be extra padding between points
     while offset < point_step:
@@ -159,7 +152,7 @@ def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None):
     cloud_msg.height = cloud_arr.shape[0]
     cloud_msg.width = cloud_arr.shape[1]
     cloud_msg.fields = dtype_to_fields(cloud_arr.dtype)
-    cloud_msg.is_bigendian = False # assumption
+    cloud_msg.is_bigendian = sys.byteorder != 'little',
     cloud_msg.point_step = cloud_arr.dtype.itemsize
     cloud_msg.row_step = cloud_msg.point_step*cloud_arr.shape[1]
     cloud_msg.is_dense = \

--- a/ros2_numpy/point_cloud2.py
+++ b/ros2_numpy/point_cloud2.py
@@ -152,7 +152,7 @@ def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None):
     cloud_msg.height = cloud_arr.shape[0]
     cloud_msg.width = cloud_arr.shape[1]
     cloud_msg.fields = dtype_to_fields(cloud_arr.dtype)
-    cloud_msg.is_bigendian = sys.byteorder != 'little',
+    cloud_msg.is_bigendian = sys.byteorder != 'little'
     cloud_msg.point_step = cloud_arr.dtype.itemsize
     cloud_msg.row_step = cloud_msg.point_step*cloud_arr.shape[1]
     cloud_msg.is_dense = \

--- a/ros2_numpy/point_cloud2.py
+++ b/ros2_numpy/point_cloud2.py
@@ -79,7 +79,7 @@ def fields_to_dtype(fields, point_step):
             dtype = np.dtype((dtype, f.count))
 
         np_dtype_list.append((f.name, dtype))
-        offset += type_mappings[f.datatype].itemsize * f.count
+        offset += pftype_to_nptype[f.datatype].itemsize * f.count
 
     # might be extra padding between points
     while offset < point_step:

--- a/ros2_numpy/registry.py
+++ b/ros2_numpy/registry.py
@@ -1,5 +1,5 @@
 import functools
-import collections
+from collections.abc import Sequence
 
 _to_numpy = {}
 _from_numpy = {}
@@ -21,7 +21,7 @@ def numpify(msg, *args, **kwargs):
         return
 
     conv = _to_numpy.get((msg.__class__, False))
-    if not conv and isinstance(msg, collections.Sequence):
+    if not conv and isinstance(msg, Sequence):
         if not msg:
             raise ValueError("Cannot determine the type of an empty Collection")
         conv = _to_numpy.get((msg[0].__class__, True))


### PR DESCRIPTION
This pull request replaces the `pftype_sizes` mapping with a query to `type_mappings` using the `itemsize` attribute of the returned dtype.

It also adds support for big-endian CPU architectures.