### PR TITLE
support pointcloud access with custom specified fields 'x','y',...

### DIFF
--- a/ros2_numpy/registry.py
+++ b/ros2_numpy/registry.py
@@ -35,6 +35,8 @@ def numpify(msg, *args, **kwargs):
                           for cls, pl in _to_numpy.keys())
         ))
 
+    print(*args)
+
     return conv(msg, *args, **kwargs)
 
 def msgify(msg_type, numpy_obj, *args, **kwargs):

--- a/test/test_pointclouds.py
+++ b/test/test_pointclouds.py
@@ -89,5 +89,13 @@ class TestPointClouds(unittest.TestCase):
 
         np.testing.assert_equal(points_arr, new_points_arr)
 
+    def test_field_access(self):
+        points_arr = self.makeArray(3)
+        cloud_msg = rnp.msgify(PointCloud2, points_arr)
+        points_xyz = rnp.point_cloud2.pointcloud2_to_array(cloud_msg, fields=['x', 'y', 'z'])
+
+        np.testing.assert_equal(points_xyz, rnp.point_cloud2.pointcloud2_to_xyz_array(cloud_msg))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows direct access by pointcloud fields, e.g. on KITTI dataset

```
points_xyzi = rnp.point_cloud2.pointcloud2_to_array(cloud_msg, fields=['x', 'y', 'z', 'intensity'])
```

Tests are passing.