### PR TITLE
Switch testing framework from nose to pytest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,17 +9,6 @@ find_package(geometry_msgs REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-if(BUILD_TESTING)
-  find_package(rclpy REQUIRED)
-  find_package(ament_cmake_nose REQUIRED)
-
-  ament_add_nose_test(pointclouds test/test_pointclouds.py)
-  ament_add_nose_test(images test/test_images.py)
-  ament_add_nose_test(occupancygrids test/test_occupancygrids.py)
-  ament_add_nose_test(geometry test/test_geometry.py)
-  ament_add_nose_test(quaternions test/test_quat.py)
-endif()
-
 ##############
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(ament_cmake_python)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,28 @@ find_package(geometry_msgs REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(rclpy REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
+
+  set(_pytest_tests
+    test/test_pointclouds.py
+    test/test_images.py
+    test/test_occupancygrids.py
+    test/test_geometry.py
+    test/test_quat.py
+    # Add other test files here
+  )
+  foreach(_test_path ${_pytest_tests})
+    get_filename_component(_test_name ${_test_path} NAME_WE)
+    ament_add_pytest_test(${_test_name} ${_test_path}
+      APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+      TIMEOUT 60
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+  endforeach()
+endif()
+
 ##############
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(ament_cmake_python)

--- a/package.xml
+++ b/package.xml
@@ -25,8 +25,6 @@
 
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <test_depend>ament_cmake_nose</test_depend>
-  <test_depend>python3-nose</test_depend>
   <test_depend>rclpy</test_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,8 @@
 
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
 
   <export>


### PR DESCRIPTION
Nose was deprecated, so they [removed the nose ament_cmake package](https://github.com/ament/ament_cmake/pull/435) from the ROS 2 Iron packages. Therefore `find_package(ament_cmake_nose REQUIRED)` errors out when using this package with Iron. This PR changes the runner framework from nose to pytest. This should work on both Humble and Iron.